### PR TITLE
Deprecation warning in Rails 3.2

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -1,7 +1,7 @@
 module RailsSettings
   class Settings < ActiveRecord::Base
     
-    set_table_name 'settings'
+		self.table_name = 'settings'
     
     class SettingNotFound < RuntimeError; end
     


### PR DESCRIPTION
Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead.
