### PR TITLE
move cache_store(Rails.cache) to method

### DIFF
--- a/lib/rails-settings/cached_settings.rb
+++ b/lib/rails-settings/cached_settings.rb
@@ -1,16 +1,21 @@
 module RailsSettings
   class CachedSettings < Settings
+
+    def self.cache_store
+      Rails.cache
+    end
+
     after_update :rewrite_cache    
     after_create :rewrite_cache
     def rewrite_cache
-      Rails.cache.write("settings:#{self.var}", self.value)
+      self.class.cache_store.write("settings:#{self.var}", self.value)      
     end
     
-    after_destroy { |record| Rails.cache.delete("settings:#{record.var}") }
+    after_destroy { |record| record.class.cache_store.delete("settings:#{record.var}") }
     
     def self.[](var_name)
       cache_key = "settings:#{var_name}"
-      obj = Rails.cache.fetch(cache_key) {
+      obj = cache_store.fetch(cache_key) {
         super(var_name)
       }
       obj == nil ? @@defaults[var_name.to_s] : obj


### PR DESCRIPTION
With these changes, gem can be used independently of the `Rails`.

In my case, I requie "activerecord" and "activesupport" (without Rails).
I can use 'rails-settings-cached' in daemons as well as in my Rails app (with single cache_store)

For non-Rails usage you can define cache_store like this:

```
class Settings < RailsSettings::CachedSettings
  def self.cache_store
     ActiveSupport::Cache.lookup_store(:redis_store)
  end
end
```

or

```
class Settings < RailsSettings::CachedSettings
  def self.cache_store
    @redis_cache_store ||=
      if defined?(Rails)
        Rails.cache
      else
        ActiveSupport::Cache.lookup_store(:redis_store)
      end
  end
end
```
