### PR TITLE
enable destroy-ing a key with falsy data

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -32,7 +32,7 @@ module RailsSettings
     #destroy the specified settings record
     def self.destroy(var_name)
       var_name = var_name.to_s
-      if self[var_name]
+      if self.all.key?(var_name)
         object(var_name).destroy
         true
       else

--- a/spec/rails-settings-cached/setting_spec.rb
+++ b/spec/rails-settings-cached/setting_spec.rb
@@ -76,7 +76,13 @@ describe RailsSettings do
       Setting.foo.should == nil
       Setting.all.count.should == 7
     end
-    
+
+    it "can destroy a falsy value" do
+      Setting.falsy_value = false
+      Setting.destroy(:falsy_value)
+      Setting.falsy_value.should == nil
+    end
+
     it "can work with default value" do
       Setting.defaults[:bar] = @bar
       Setting.bar.should == @bar


### PR DESCRIPTION
problem: if you store a falsy value then you cannot destroy it because

``` ruby
if self[var_name]
```

returns false and so `destroy()` raises a SettingNotFoundException

so instead we can check that the key exists
