### PR TITLE
better patch for destroying keys with falsy values. doesn't require loading all settings first.

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -32,8 +32,9 @@ module RailsSettings
     #destroy the specified settings record
     def self.destroy(var_name)
       var_name = var_name.to_s
-      if self.all.key?(var_name)
-        object(var_name).destroy
+      obj = object(var_name)
+      unless obj.nil?
+        obj.destroy
         true
       else
         raise SettingNotFound, "Setting variable \"#{var_name}\" not found"


### PR DESCRIPTION
thanks for accepting my earlier pull to allow deleting keys with falsy values.

this is an improvement upon that patch that doesn't require that we load all the settings and iterate through the keys. instead, like `[]`, we use `object(var_name)`.

passes the same test I added earlier.
