### PR TITLE
Fix method name cannot be setting's key

### DIFF
--- a/lib/rails-settings/cached_settings.rb
+++ b/lib/rails-settings/cached_settings.rb
@@ -21,8 +21,8 @@ module RailsSettings
       end
 
       def save_default(key, value)
-        return false unless send(key).nil?
-        send("#{key}=", value)
+        return false unless self[key].nil?
+        self[key] = value
       end
     end
   end


### PR DESCRIPTION
Hi huacnlee,
I found that `save_default` cannot work if there is the same name of a method defined.
For example, `Settng.save_default('name', 'foo') # It would fail`, because `Setting.name` would output `"Setting"`.
I think that there may be several kinds of solutions for it.
The patch I submitted is just to fix the problem with the fewest code change.
But I think that it may be a better idea to raise an exception when a user tries to assign a key which name is a conflict with built-in methods.
I would be appreciated hearing your opinion.
Thanks a lot. :smile: