### PR TITLE
Allow setting dynamic cache prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ User.without_settings('color')
 # returns a scope of users having no 'color' setting (means user.settings.color == nil)
 ```
 
+Settings maybe dynamically scoped. For example, if you're using [apartment gem](https://github.com/influitive/apartment) for multitenancy, you may not want tenants to share settings:
+
+```ruby
+class Settings < RailsSettings::CachedSettings
+  cache_prefix { Apartment::Tenant.current }
+  ...
+end
+```
+
 -----
 
 ## How to create a list, form to manage Settings?

--- a/lib/rails-settings/cached_settings.rb
+++ b/lib/rails-settings/cached_settings.rb
@@ -13,8 +13,13 @@ module RailsSettings
     end
 
     class << self
+      def cache_prefix(&block)
+        @cache_prefix = block
+      end
+
       def cache_key(var_name, scope_object)
         scope = "rails_settings_cached:"
+        scope << "#{@cache_prefix.call}:" if @cache_prefix
         scope << "#{scope_object.class.name}-#{scope_object.id}:" if scope_object
         scope << "#{var_name}"
       end

--- a/spec/rails-settings-cached/cached_setting_spec.rb
+++ b/spec/rails-settings-cached/cached_setting_spec.rb
@@ -17,6 +17,13 @@ describe RailsSettings::CachedSettings do
     end
   end
 
+  describe '.cache_prefix' do
+    it 'sets cache key prefix' do
+      described_class.cache_prefix { "stuff" }
+      expect(described_class.cache_key('abc', nil)).to eql("rails_settings_cached:stuff:abc")
+    end
+  end
+
   describe 'Unscoped' do
     it 'should set a key and fetch with one query' do
       expect(Setting.test_cache).to eq(nil)


### PR DESCRIPTION
So that settings can be arbitrarily scoped based on some
context (e.g. current tenant).