### PR TITLE
declare supported ruby versions as requirement

### DIFF
--- a/rails-settings-cached.gemspec
+++ b/rails-settings-cached.gemspec
@@ -2,6 +2,7 @@
 Gem::Specification.new do |s|
   s.name = 'rails-settings-cached'
   s.version = '0.5.0'
+  s.required_ruby_version = '>= 2.0'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Squeegy', 'Georg Ledermann', '100hz', 'Jason Lee']


### PR DESCRIPTION
Enabling the use for an generally [unsupported platform without any security support](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/) would send wrong signals and maintenance for it shouldn't be relevant at all.

This PR IMHO should make #74 obsolete.