### PR TITLE
Update the cached value for the key when value set

### DIFF
--- a/lib/rails-settings/cached_settings.rb
+++ b/lib/rails-settings/cached_settings.rb
@@ -36,6 +36,15 @@ module RailsSettings
         end
       end
 
+      # set a setting value by [] notation
+      def []=(var_name, value)
+        super
+
+        Rails.cache.write(cache_key(var_name, @object),value)
+
+        value
+      end
+
       def save_default(key, value)
         return false unless self[key].nil?
         self[key] = value


### PR DESCRIPTION
If setting a cache value is called within a TX and then the value is
accessed, then the old value is retrieved from the cache.

The fix is to clear the cached value for the var name immediately after
calling save!. Note, it is still appropriate to clear cache values upon
commit due to race conditions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/huacnlee/rails-settings-cached/86)
<!-- Reviewable:end -->
