### PR TITLE
update cache when setting a value

### DIFF
--- a/lib/rails-settings/cached_settings.rb
+++ b/lib/rails-settings/cached_settings.rb
@@ -35,6 +35,11 @@ module RailsSettings
           value
         end
       end
+      
+      def []=(var_name,value)
+      	Rails.cache.write(cache_key(var_name, @object),value)
+      	super(var_name,value)
+      end
 
       def save_default(key, value)
         return false unless self[key].nil?


### PR DESCRIPTION
Update the Rails cache as soon as a value is set.

This solves the transaction issues especially in Rails 4.2 tests.