### PR TITLE
Administrate integration

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -16,7 +16,7 @@ module RailsSettings
 
     # get the value field, YAML decoded
     def value
-      YAML.load(self[:value])
+      YAML.load(self[:value]) if self[:value].present?
     end
 
     # set the value field, YAML encoded


### PR DESCRIPTION
Hi. To integrate with gem [administrate](https://github.com/thoughtbot/administrate), it is necessary to `Setting.new.value` return `nil`, otherwise we get this error:

```
TypeError - no implicit conversion of nil into String:
  /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/psych.rb:370:in `parse_stream'
  /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/psych.rb:318:in `parse'
  /usr/local/var/rbenv/versions/2.2.2/lib/ruby/2.2.0/psych.rb:245:in `load'
  rails-settings-cached (0.5.2) lib/rails-settings/settings.rb:19:in `value'
```