### PR TITLE
New named scope for finding records with a setting with a specific value

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ User.with_settings
 User.with_settings_for('color')
 # => returns a scope of users having a 'color' setting
 
+User.with_setting_value('color', 'red')
+# => returns a scope of users having a 'color' setting with value 'red'
+
 User.without_settings
 # returns a scope of users having no setting at all (means user.settings.get_all == {})
 

--- a/lib/rails-settings/extend.rb
+++ b/lib/rails-settings/extend.rb
@@ -14,6 +14,12 @@ module RailsSettings
                                  settings.thing_type = '#{base_class.name}') AND settings.var = '#{var}'")
       }
 
+      scope :with_setting_value, lambda { |var, value|
+        joins("JOIN settings ON (settings.thing_id = #{table_name}.#{primary_key} AND settings.thing_type = '#{base_class.name}')
+                         AND settings.var = '#{var}'
+                         AND settings.value = #{ActiveRecord::Base.connection.quote(value.to_yaml)}")
+      }
+
       scope :without_settings, lambda {
         joins("LEFT JOIN settings ON (settings.thing_id = #{table_name}.#{primary_key} AND
                                       settings.thing_type = '#{base_class.name}')")

--- a/spec/rails-settings-cached/setting_spec.rb
+++ b/spec/rails-settings-cached/setting_spec.rb
@@ -163,6 +163,17 @@ describe RailsSettings do
         expect(Setting.unscoped.find(id)).to eq obj
       end
     end
+
+    describe '#with_settings_for' do
+      it 'should only return items with matching settings' do
+        User.create.settings.color = 'green'
+        User.create.settings.color = 'red'
+        User.create.settings.color = 'green'
+
+        expect(User.with_setting_value('color', 'red').count).to be 1
+        expect(User.with_setting_value('color', 'green').count).to be 2
+      end
+    end
   end
 
   describe 'Custom table name' do


### PR DESCRIPTION
This adds a scope which allows us to find items which have a setting with a specific value.  It works just like `with_settings_for` but rather than just passing `var` you also pass `value`.
   
    # returns a scope of users having a 'color' setting with value 'red'
    User.with_setting_value('color', 'red')