### PR TITLE
Fix CachedSettings inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.6
+
+- Fixed inheritance of RailsSettings::CachedSettings to use RailsSettings::Base.
+
 ## 0.5.5
 
 - Change generator command from `rails g settings` to `rails g settings:install`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-settings-cached (0.5.5)
+    rails-settings-cached (0.5.6)
       rails (>= 4.2.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ of object. Strings, numbers, arrays, or any object.
 Edit your Gemfile:
 
 ```ruby
-gem 'rails-settings-cached', "~> 0.5.5"
+gem 'rails-settings-cached', "~> 0.5.6"
 ```
 
 Older Rails versions:

--- a/lib/rails-settings/cached_settings.rb
+++ b/lib/rails-settings/cached_settings.rb
@@ -1,5 +1,5 @@
 module RailsSettings
-  class CachedSettings < Settings
+  class CachedSettings < Base
     def rewrite_cache
       Rails.cache.write(cache_key, value)
     end

--- a/lib/rails-settings/version.rb
+++ b/lib/rails-settings/version.rb
@@ -1,7 +1,7 @@
 module RailsSettings
   class << self
     def version
-      "0.5.5"
+      "0.5.6"
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where RailsSettings::CachedSettings uses the deprecated class RailsSettings::Settings

Fixes: #95 