### PR TITLE
Fix bug preventing a value of false from being returned

### DIFF
--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -74,7 +74,13 @@ module RailsSettings
 
       # get a setting value by [] notation
       def [](var_name)
-        object(var_name).try(:value) || @@defaults[var_name.to_s]
+        if var = object(var_name)
+          var.value
+        elsif @@defaults[var_name.to_s]
+          @@defaults[var_name.to_s]
+        else
+          nil
+        end
       end
 
       # set a setting value by [] notation

--- a/spec/rails-settings-cached/setting_spec.rb
+++ b/spec/rails-settings-cached/setting_spec.rb
@@ -31,8 +31,14 @@ describe RailsSettings do
         Setting.boolean_bar = false
       end
 
-      it { expect(Setting.boolean_foo).to be_truthy }
-      it { expect(Setting.boolean_bar).to be_falsey }
+      it { expect(Setting.boolean_foo).to be true }
+      it { expect(Setting.boolean_bar).to be false }
+
+      it "returns the same values if the cache is cleared" do
+        Rails.cache.clear
+        expect(Setting.boolean_foo).to be true
+        expect(Setting.boolean_bar).to be false
+      end
     end
 
     context 'Array value' do


### PR DESCRIPTION
If the value was set to false, either the default is returned or if
there is no default, then nil would be returned.

I have added a test that would previously fail that now passes.