### PR TITLE
Ensure defaults not overwrite persisted settings

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -58,7 +58,7 @@ module RailsSettings
           defaults = starting_with.nil? ? Default.instance : Default.instance.fetch(starting_with, {})
         end
 
-        result.merge! defaults
+        result.reverse_merge! defaults
 
         result.with_indifferent_access
       end

--- a/spec/rails-settings-cached/setting_spec.rb
+++ b/spec/rails-settings-cached/setting_spec.rb
@@ -100,6 +100,11 @@ describe RailsSettings do
       expect(Setting.get_all('config')).to eq({ "config.color" => :red, "config.limit" => 100 })
       expect(Setting.get_all('config').count).to eq 2
     end
+
+    it 'overwrites default values' do
+      Setting.str = 'abc'
+      expect(Setting.get_all['str']).to eq('abc')
+    end
   end
 
   describe '#destroy' do
@@ -108,7 +113,7 @@ describe RailsSettings do
     end
 
     it { expect(Setting.foo).to be_nil }
-    it { expect(Setting.all.count).to eq 7 }
+    it { expect(Setting.all.count).to eq 8 }
 
     it 'can destroy a falsy value' do
       Setting.falsy_value = false


### PR DESCRIPTION
This addresses an issue with `#get_all` and default values. If a default value exists for key `x` and a value for `x` also exists in the database, the current implementation of `#get_all` will override the database value with the default value.

I also noticed that the current test suite is order dependent. Try running the test suite with `rspec --order rand` and things start t o break in all kinds of interesting ways.