### PR TITLE
Fix deprecated syntax in the model generator

### DIFF
--- a/lib/generators/settings/templates/model.rb
+++ b/lib/generators/settings/templates/model.rb
@@ -1,5 +1,5 @@
 # RailsSettings Model
-class <%= class_name %> < RailsSettings::CachedSettings
+class <%= class_name %> < RailsSettings::Base
   source Rails.root.join("config/app.yml")
   namespace Rails.env
 end


### PR DESCRIPTION
DEPRECATION WARNING: RailsSettings::CachedSettings is deprecated and it will removed in 0.7.0. Please use RailsSettings::Base instead.