### PR TITLE
Fix defaults merge when get_all.

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -55,7 +55,7 @@ module RailsSettings
 
         defaults = {}
         if Default.enabled?
-          defaults = starting_with.nil? ? Default.instance : Default.instance.fetch(starting_with, {})
+          defaults = starting_with.nil? ? Default.instance : Default.instance.select { |key, _| key.to_s.start_with?(starting_with) }
         end
 
         result.reverse_merge! defaults

--- a/spec/rails-settings-cached/setting_spec.rb
+++ b/spec/rails-settings-cached/setting_spec.rb
@@ -96,6 +96,11 @@ describe RailsSettings do
       expect(Setting.get_all).to include(:default1, :default2)
     end
 
+    it "should include namespace defaults" do
+      expect(RailsSettings::Default).to receive(:instance).and_return({ "test.default1" => 1, "test.default2" => '2', demo: 3 })
+      expect(Setting.get_all('test.')).to include(:'test.default1', :'test.default2')
+    end
+
     it "should all('namespace')" do
       expect(Setting.get_all('config')).to eq({ "config.color" => :red, "config.limit" => 100 })
       expect(Setting.get_all('config').count).to eq 2


### PR DESCRIPTION
Subj. Select defaults, not fetch.
Otherwise starting_with selection can be wrong.
Also added another `defaults` fix with specs.