### PR TITLE
Add info regarding test/dev cache sharing to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Now just put that migration in the database with:
 rake db:migrate
 ```
 
+If you are having issues with cached values being shared between test runs and/or the dev enviroment add the following to development.rb and test.rb:
+
+```rb
+  config.cache_store = :memory_store
+```
+
 ## Usage
 
 The syntax is easy.  First, lets create some settings to keep track of:


### PR DESCRIPTION
The default caching system in rails is `ActiveSupport::Cache::FileStore`. This means that cached values are shared between development and test environments as well as not correctly clearing the cache between test specs. To avoid this we can set the dev and test envs to use `ActiveSupport::Cache::MemoryStore`

This issue has been mentioned previously in https://github.com/huacnlee/rails-settings-cached/issues/1 as well as on [SO](http://stackoverflow.com/questions/10352638/rails-gem-uses-the-development-db-instead-of-the-testing-one-when-executing-rak) and on the Rails repo regarding inaccurate documentation [here](https://github.com/rails/rails/issues/8130#issuecomment-10240415).
