### PR TITLE
fix bug: thread safe problem

### DIFF
--- a/lib/rails-settings/scoped_settings.rb
+++ b/lib/rails-settings/scoped_settings.rb
@@ -1,12 +1,14 @@
 module RailsSettings
   class ScopedSettings < Base
+
     def self.for_thing(object)
-      @object = object
+      Thread.current[:curren_object_for_rails_settings] = object
       self
     end
 
     def self.thing_scoped
-      unscoped.where(thing_type: @object.class.base_class.to_s, thing_id: @object.id)
+      object = Thread.current[:curren_object_for_rails_settings]
+      unscoped.where(thing_type: object.class.base_class.to_s, thing_id: object.id)
     end
   end
 end

--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -60,20 +60,20 @@ module RailsSettings
       end
 
       # get a setting value by [] notation
-      def [](var_name)
-        val = object(var_name)
-        return val.value if val
-        return Default[var_name] if Default.enabled?
+      def [](key)
+        return super(key) unless rails_initialized?
+        object = Thread.current[:curren_object_for_rails_settings]
+        val = Rails.cache.fetch(cache_key(key, object)) do
+          super(key)
+        end
+        val
       end
 
       # set a setting value by [] notation
       def []=(var_name, value)
-        var_name = var_name.to_s
-
-        record = object(var_name) || thing_scoped.new(var: var_name)
-        record.value = value
-        record.save!
-
+        super
+        object = Thread.current[:curren_object_for_rails_settings]
+        Rails.cache.write(cache_key(var_name, object), value)
         value
       end
 


### PR DESCRIPTION
主要是修复 线程安全问题

测试代码:
```
def test 
  user_one = User.find(1)
  user_two = User.find(1)
  items_1 = []

  a = Thread.new do
    puts "thread 1 start #{Time.now.strftime("%H:%M:%S.%N")}"
    10000.times.each do 
      s = candao.settings
      items_1 << s.where(:var => "a").to_sql
    end
    puts "thread 1 end #{Time.now.strftime("%H:%M:%S.%N")}"
  end

  items_2 = []
  b = Thread.new do
    puts "thread 2 start #{Time.now.strftime("%H:%M:%S.%N")}"
    10000.times.each do 
      s = wangdiantong.settings
      items_2 << s.where(:var => "a").to_sql
    end
    puts "thread 2 end #{Time.now.strftime("%H:%M:%S.%N")}"
  end
  a.join; b.join
  return [items_1, items_2]
end

items_1, items_2 = test

puts items_1.uniq;nil
puts items_2.uniq;nil
```

修复前: 运行代码后 会发现 items_1.uniq 和 items_2.uniq 都会包含
```
"SELECT \"settings\".* FROM \"settings\" WHERE \"settings\".\"thing_type\" = 'User' AND \"settings\".\"thing_id\" = 1 AND \"settings\".\"var\" = 'a'"

"SELECT \"settings\".* FROM \"settings\" WHERE \"settings\".\"thing_type\" = 'User' AND \"settings\".\"thing_id\" =2 AND \"settings\".\"var\" = 'a'"
```

修复后: 就不会交叉到一起了



