### PR TITLE
Remove "rails" requirement (require "activesupport" && "activerecord")

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     rails-settings-cached (0.6.6)
-      rails (>= 4.2.0)
+      activerecord (>= 4.2.0)
+      activesupport (>= 4.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -159,4 +160,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Now just put that migration in the database with:
 rake db:migrate
 ```
 
+You need to set cache_store directly
+config/initializers/rails_settings.rb
+```ruby
+  RailsSettings::Settings.config do |config|
+    # setup new cache store
+    # config.cache_store = ActiveSupport::Cache::MemoryStore.new
+    # or use it from Rails
+    config.cache_store = Rails.cache
+  end
+```
+
 ## Usage
 
 The syntax is easy.  First, lets create some settings to keep track of:

--- a/lib/rails-settings-cached.rb
+++ b/lib/rails-settings-cached.rb
@@ -4,8 +4,9 @@ require_relative 'rails-settings/cached_settings'
 require_relative 'rails-settings/scoped_settings'
 require_relative 'rails-settings/default'
 require_relative 'rails-settings/extend'
-require_relative 'rails-settings/railtie'
 require_relative 'rails-settings/version'
 
 module RailsSettings
 end
+
+require_relative 'rails-settings/railtie' if defined?(Rails)

--- a/lib/rails-settings/default.rb
+++ b/lib/rails-settings/default.rb
@@ -14,7 +14,7 @@ module RailsSettings
       end
 
       def source_path
-        @source || Rails.root.join('config/app.yml')
+        @source || (Rails.root.join('config/app.yml') if defined?(Rails))
       end
 
       def [](key)
@@ -39,7 +39,8 @@ module RailsSettings
     def initialize
       content = open(self.class.source_path).read
       hash = content.empty? ? {} : YAML.load(ERB.new(content).result).to_hash
-      hash = hash[Rails.env] || {}
+      hash = hash[Rails.env] if defined?(Rails)
+      hash ||= {}
       replace hash
     end
   end

--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -17,6 +17,15 @@ module RailsSettings
     end
 
     class << self
+      attr_accessor :cache_store
+
+      # cache_store must be instance of
+      # ActiveSupport::Cache::Store
+
+      def config
+        yield self if block_given?
+      end
+
       # get or set a variable with the variable as the called method
       # rubocop:disable Style/MethodMissing
       def method_missing(method, *args)
@@ -103,8 +112,15 @@ module RailsSettings
         Default.source(filename)
       end
 
+      def no_cache_store?
+        cache_store.nil?
+      end
+
       def rails_initialized?
-        Rails.application && Rails.application.initialized?
+        Kernel.warn 'DEPRECATION WARNING: Settings rails_initialized? is deprecated ' \
+                    'and it will removed in 0.7.0. ' \
+                    'Please use no_cache_store? for detect cache presence.'
+        true
       end
 
       private

--- a/lib/rails-settings/version.rb
+++ b/lib/rails-settings/version.rb
@@ -1,7 +1,7 @@
 module RailsSettings
   class << self
     def version
-      '0.6.6'
+      '0.6.7'
     end
   end
 end

--- a/rails-settings-cached.gemspec
+++ b/rails-settings-cached.gemspec
@@ -22,8 +22,10 @@ Gem::Specification.new do |s|
   You can store any kind of object.  Strings, numbers, arrays, or any object.
   """
 
-  s.add_dependency 'rails', '>= 4.2.0'
+  s.add_dependency 'activesupport', '>= 4.2.0'
+  s.add_dependency 'activerecord', '>= 4.2.0'
 
+  s.add_development_dependency 'rails', '>= 4.2.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rubocop', '0.46.0'
   s.add_development_dependency 'simplecov'

--- a/spec/rails-settings-cached/cached_setting_spec.rb
+++ b/spec/rails-settings-cached/cached_setting_spec.rb
@@ -1,7 +1,13 @@
 require 'spec_helper'
 
 describe RailsSettings::CachedSettings do
-  before(:each) { Rails.cache.clear }
+  before(:each) do
+    RailsSettings::Settings.config do |config|
+      # setup cache store from Rails.cache
+      config.cache_store = Rails.cache
+    end
+    Rails.cache.clear
+  end
 
   describe '.cache_key' do
     before do


### PR DESCRIPTION
Remove "rails" requirement (require "activesupport" && "activerecord")
Now cache feature available only if cache_store defined in code like this:
```
    RailsSettings::Settings.config do |config|
      # setup cache store
      config.cache_store = ActiveSupport::Cache::MemoryStore.new
    end
```
Related to issue: https://github.com/huacnlee/rails-settings-cached/issues/58