### PR TITLE
Use Hash#dig to fetch nested defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.8
-  - 2.2.2
   - 2.3.0
   - 2.4.0
+  - 2.4.3
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-4-2

--- a/lib/rails-settings/default.rb
+++ b/lib/rails-settings/default.rb
@@ -27,7 +27,6 @@ module RailsSettings
       def instance
         return @instance if defined? @instance
         @instance = new
-        @instance
       end
     end
 

--- a/lib/rails-settings/default.rb
+++ b/lib/rails-settings/default.rb
@@ -21,12 +21,7 @@ module RailsSettings
         # foo.bar.dar Nested fetch value
         return instance[key] if instance.key?(key)
         keys = key.to_s.split('.')
-        val = instance
-        keys.each do |k|
-          val = val.fetch(k.to_s, nil)
-          break if val.nil?
-        end
-        val
+        instance.dig(*keys)
       end
 
       def instance

--- a/rails-settings-cached.gemspec
+++ b/rails-settings-cached.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/huacnlee/rails-settings-cached'
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.3'
   s.summary = "Settings plugin for Rails that makes managing a table of global keys."
   s.description = """
   This is improved from rails-settings, added caching.


### PR DESCRIPTION
Performance should be slightly better than #fetch (https://github.com/JuanitoFatas/fast-ruby#hashdig-vs-hash-vs-hashfetch-code)
And i propose to drop support of older ruby version that does not support `Hash#dig` (< 2.3.0)