### PR TITLE
Split single app.yml into separate files under config/settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Setting.all('preferences.')
 # returns { 'preferences.color' => :blue, 'preferences.size' => :large }
 ```
 
+Want to store settings in custom file or in separate files?
+```ruby
+class Setting < RailsSettings::Base
+  source Rails.root.join("config/site_config.yml")
+  # or use array
+  source Rails.root.join("config/app.yml"), Rails.root.join("config/settings/*.yml")
+end
+```
+
+
 ## Extend a model
 
 Settings may be bound to any existing ActiveRecord object. Define this association like this:

--- a/lib/rails-settings/default.rb
+++ b/lib/rails-settings/default.rb
@@ -6,15 +6,15 @@ module RailsSettings
 
     class << self
       def enabled?
-        source_path && File.exist?(source_path)
+        source_paths && source_paths.any? { |path| File.exist?(path) }
       end
 
-      def source(value = nil)
-        @source ||= value
+      def source(*paths)
+        @source = Dir.glob(paths)
       end
 
-      def source_path
-        @source || Rails.root.join('config/app.yml')
+      def source_paths
+        @source || [Rails.root.join('config/app.yml')]
       end
 
       def [](key)
@@ -31,7 +31,10 @@ module RailsSettings
     end
 
     def initialize
-      content = open(self.class.source_path).read
+      content =
+        self.class.source_paths.map do |path|
+          open(path).read
+        end.join("\n")
       hash = content.empty? ? {} : YAML.load(ERB.new(content).result).to_hash
       hash = hash[Rails.env] || {}
       replace hash

--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -99,8 +99,8 @@ module RailsSettings
         unscoped.where('thing_type is NULL and thing_id is NULL')
       end
 
-      def source(filename)
-        Default.source(filename)
+      def source(*filename)
+        Default.source(*filename)
       end
 
       def rails_initialized?

--- a/spec/rails-settings-cached/default_setting_spec.rb
+++ b/spec/rails-settings-cached/default_setting_spec.rb
@@ -10,7 +10,7 @@ describe RailsSettings::Default do
 
   describe 'YMLSetting config' do
     it { expect(RailsSettings::Default.enabled?).to eq true }
-    it { expect(RailsSettings::Default.source_path.to_s).to eq File.expand_path('../../config/app.yml', __FILE__) }
+    it { expect(RailsSettings::Default.source_paths.map(&:to_s)).to eq [File.expand_path('../../config/app.yml', __FILE__)] }
   end
 
   describe 'It can work without tables' do


### PR DESCRIPTION
I propose to split app.yml into separate files because sometimes it can be very huge, if you have hundreds of keys your app.yml will become a total mess, anyway scope dividing it's a good practice like dotenv etc.
Based on this discussion: https://github.com/huacnlee/rails-settings-cached/pull/132