### PR TITLE
Only load default config file if it exists

### DIFF
--- a/lib/rails-settings/default.rb
+++ b/lib/rails-settings/default.rb
@@ -14,7 +14,8 @@ module RailsSettings
       end
 
       def source_path
-        @source || Rails.root.join("config/app.yml")
+        default_file = "config/app.yml"
+        @source || Rails.root.join(default_file) if File.exist?(default_file)
       end
 
       def [](key)


### PR DESCRIPTION
Installations that do not have a 'config/app.yml' file will fail to start. This just adds a simple test for the file before attempting to load it.