### PR TITLE
Add version spec to Gemfile in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ of object. Strings, numbers, arrays, or any object.
 Edit your Gemfile:
 
 ```ruby
-gem "rails-settings-cached"
+gem "rails-settings-cached", "~> 2.0"
 ```
 
 Generate your settings:


### PR DESCRIPTION
Following semver, it was apparent that 2.x would have breaking changes, but my bundle was auto-updated to 2.x without the version spec in the gem file.

Might be good to specify a version requirement in the readme example, as many gems do:

```ruby
gem "rails-settings-cached", "~> 2.0"
```

Then once a future breaking version is released (e.g. 3.x.x or 4.x.x) it won't break existing codebases without an intentional upgrade to the new major version.