### PR TITLE
Fix migration version for Rails 6

### DIFF
--- a/lib/generators/settings/install_generator.rb
+++ b/lib/generators/settings/install_generator.rb
@@ -32,12 +32,16 @@ module Settings
       migration_template "migration.rb", "db/migrate/create_settings.rb", migration_version: migration_version
     end
 
-    def rails5?
-      Rails.version.start_with? "5"
+    def rails_version_major
+      Rails::VERSION::MAJOR
+    end
+
+    def rails_version_minor
+      Rails::VERSION::MINOR
     end
 
     def migration_version
-      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if rails5?
+      "[#{rails_version_major}.#{rails_version_minor}]" if rails_version_major >= 5
     end
   end
 end

--- a/lib/rails-settings/version.rb
+++ b/lib/rails-settings/version.rb
@@ -3,7 +3,7 @@
 module RailsSettings
   class << self
     def version
-      "2.1.0"
+      "2.1.1"
     end
   end
 end


### PR DESCRIPTION
The generator was explicitly checking if the Rails major version was 5 so the migration version wasn't being set in a Rails 6 project. Assuming using a migration version will continue being the standard this PR changes that check to Rails >= 5.