### PR TITLE
docs: remove obsolete `get_settings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,6 @@ app/controllers/admin/settings_controller.rb
 ```rb
 module Admin
   class SettingsController < ApplicationController
-    before_action :get_setting, only: [:edit, :update]
-
     def create
       setting_params.keys.each do |key|
         Setting.send("#{key}=", setting_params[key].strip) unless setting_params[key].nil?


### PR DESCRIPTION
Hey @huacnlee is it possible that this line is nowhere defined? Or am I missing something?

I searched `get_settings` in this repository and could not find a definition in this code base and only some probably out-dated issues mentioning it.