### PR TITLE
Validate on assignment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+    simplecov-html (0.12.3)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -152,7 +152,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.0)
+    sqlite3 (1.4.2)
     thor (1.0.1)
     tzinfo (2.0.3)
       concurrent-ruby (~> 1.0)
@@ -164,6 +164,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   codecov
@@ -176,4 +177,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.3
+   2.2.0

--- a/README.md
+++ b/README.md
@@ -162,9 +162,23 @@ class Setting < RailsSettings::Base
 end
 ```
 
-Now validate will work on record save.
+Now validate will work on record save:
 
 ```rb
+irb> Setting.app_name = ""
+ActiveRecord::RecordInvalid: (Validation failed: App name can't be blank)
+irb> Setting.app_name = "Rails Settings"
+"Rails Settings"
+irb> Setting.default_locale = "zh-TW"
+ActiveRecord::RecordInvalid: (Validation failed: Default locale is not included in [zh-CN, en, jp])
+irb> Setting.default_locale = "en"
+"en"
+```
+
+Validate by `save` / `valid?` method:
+
+```rb
+
 setting = Setting.find_or_initialize_by(var: :app_name)
 setting.value = ""
 setting.valid?

--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -95,7 +95,7 @@ module RailsSettings
             value = send(:_convert_string_to_typeof_value, type, value, separator: separator)
 
             record.value = value
-            record.save(validate: false)
+            record.save!
 
             value
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -91,4 +91,9 @@ class ActiveSupport::TestCase
     assert_equal true, model.errors.has_key?(key), "#{model.errors.messages.keys} not include #{key}"
     assert_equal messages, model.errors.full_messages_for(key)
   end
+
+  def assert_raise_with_validation_message(message)
+    ex = assert_raise(ActiveRecord::RecordInvalid) {yield}
+    assert_equal message, ex.message
+  end
 end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -35,4 +35,25 @@ class ValidationTest < ActiveSupport::TestCase
     assert_equal true, setting.valid?
     assert_equal 0, setting.errors.size
   end
+
+  test "validation with assignment" do
+    assert_raise_with_validation_message("Validation failed: Host can't be blank") do
+      Setting.host = ""
+    end
+    assert_nothing_raised do
+      Setting.host = "foo"
+    end
+
+    assert_raise_with_validation_message("Validation failed: Mailer provider is not included in the list") do
+      Setting.mailer_provider = "foo"
+    end
+    assert_nothing_raised do
+      Setting.host = "smtp"
+    end
+  end
+end
+
+def assert_raise_with_validation_message(message)
+  ex = assert_raise(ActiveRecord::RecordInvalid) {yield}
+  assert_equal message, ex.message
 end


### PR DESCRIPTION
https://github.com/huacnlee/rails-settings-cached/pull/201

```rb
irb> Setting.app_name = ""
ActiveRecord::RecordInvalid: (Validation failed: App name can't be blank)
irb> Setting.app_name = "Rails Settings"
"Rails Settings"
irb> Setting.default_locale = "zh-TW"
ActiveRecord::RecordInvalid: (Validation failed: Default locale is not included in [zh-CN, en, jp])
irb> Setting.default_locale = "en"
"en"
```

This changes can backward compatible, because the old version not have `validates` option.