### PR TITLE
Add ability to define custom data types

### DIFF
--- a/lib/rails-settings-cached.rb
+++ b/lib/rails-settings-cached.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "rails-settings/fields/array"
+require_relative "rails-settings/fields/base"
+require_relative "rails-settings/fields/big_decimal"
+require_relative "rails-settings/fields/boolean"
+require_relative "rails-settings/fields/float"
+require_relative "rails-settings/fields/hash"
+require_relative "rails-settings/fields/integer"
+require_relative "rails-settings/fields/string"
+
 require_relative "rails-settings/base"
 require_relative "rails-settings/request_cache"
 require_relative "rails-settings/middleware"
@@ -7,4 +16,6 @@ require_relative "rails-settings/railtie"
 require_relative "rails-settings/version"
 
 module RailsSettings
+  module Fields
+  end
 end

--- a/lib/rails-settings-cached.rb
+++ b/lib/rails-settings-cached.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "rails-settings/fields/array"
 require_relative "rails-settings/fields/base"
+require_relative "rails-settings/fields/array"
 require_relative "rails-settings/fields/big_decimal"
 require_relative "rails-settings/fields/boolean"
 require_relative "rails-settings/fields/float"

--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -123,22 +123,6 @@ module RailsSettings
         end
       end
 
-      def _value_of(var_name)
-        unless _table_exists?
-          # Fallback to default value if table was not ready (before migrate)
-          puts "WARNING: table: \"#{table_name}\" does not exist or not database connection, `#{name}.#{var_name}` fallback to returns the default value."
-          return nil
-        end
-
-        _all_settings[var_name]
-      end
-
-      def _table_exists?
-        table_exists?
-      rescue
-        false
-      end
-
       def rails_initialized?
         Rails.application&.initialized?
       end

--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -68,15 +68,15 @@ module RailsSettings
       end
 
       def keys
-        @defined_fields.map { |field| field.key }
+        @defined_fields.map(&:key)
       end
 
       def editable_keys
-        @defined_fields.reject { |field| field.readonly }.map { |field| field.key }
+        @defined_fields.reject(&:readonly).map(&:key)
       end
 
       def readonly_keys
-        @defined_fields.select { |field| field.readonly }.map { |field| field.key }
+        @defined_fields.select(&:readonly).map(&:key)
       end
 
       attr_reader :defined_fields

--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -97,9 +97,9 @@ module RailsSettings
         @defined_fields << field
 
         if readonly
-          define_singleton_method(key) { field.convert }
+          define_singleton_method(key) { field.read }
         else
-          define_singleton_method(key) { field.convert }
+          define_singleton_method(key) { field.read }
           define_singleton_method("#{key}=") { |value| field.save!(value: value) }
 
           if validates

--- a/lib/rails-settings/fields/array.rb
+++ b/lib/rails-settings/fields/array.rb
@@ -2,7 +2,8 @@ module RailsSettings
   module Fields
     class Array < ::RailsSettings::Fields::Base
       def convert_to_value(value)
-        return value unless value.kind_of?(::String)
+        return value unless value.is_a?(::String)
+
         value.split(separator).reject(&:empty?).map(&:strip)
       end
     end

--- a/lib/rails-settings/fields/array.rb
+++ b/lib/rails-settings/fields/array.rb
@@ -3,7 +3,7 @@ module RailsSettings
     class Array < ::RailsSettings::Fields::Base
       def convert_to_value(value)
         return value unless value.kind_of?(::String)
-        value.split(separator || SEPARATOR_REGEXP).reject { |str| str.empty? }.map(&:strip)
+        value.split(separator).reject(&:empty?).map(&:strip)
       end
     end
   end

--- a/lib/rails-settings/fields/array.rb
+++ b/lib/rails-settings/fields/array.rb
@@ -1,0 +1,12 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class Array < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        return value unless value.kind_of?(::String)
+        value.split(separator || SEPARATOR_REGEXP).reject { |str| str.empty? }.map(&:strip)
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/array.rb
+++ b/lib/rails-settings/fields/array.rb
@@ -1,10 +1,14 @@
 module RailsSettings
   module Fields
     class Array < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         return value unless value.is_a?(::String)
 
         value.split(separator).reject(&:empty?).map(&:strip)
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
     end
   end

--- a/lib/rails-settings/fields/array.rb
+++ b/lib/rails-settings/fields/array.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class Array < ::RailsSettings::Fields::Base

--- a/lib/rails-settings/fields/base.rb
+++ b/lib/rails-settings/fields/base.rb
@@ -1,0 +1,54 @@
+module RailsSettings
+  module Fields
+    class Base < Struct.new(:scope, :key, :default, :readonly, :parent, :separator, :type, :options, keyword_init: true)
+      SEPARATOR_REGEXP = /[\n,;]+/
+
+      def initialize(scope:, key:, default:, parent:, readonly: false, separator: SEPARATOR_REGEXP, type: :string, options: nil)
+        self.readonly = !!readonly
+        super
+      end
+
+      def save!(value:)
+        converted_value = convert_to_value(value)
+        parent_record = parent.find_by(var: key) || parent.new(var: key)
+        parent_record.value = converted_value
+        parent_record.save!
+        converted_value
+      end
+
+      def saved_value
+        parent.send(:_value_of, key)
+      end
+
+      def default_value
+        default.is_a?(Proc) ? default.call : default
+      end
+
+      def convert
+        return convert_to_value(default_value) if readonly || saved_value.nil?
+        convert_to_value(saved_value)
+      end
+
+      def convert_to_value(value)
+        raise NotImplementedError
+      end
+
+      def to_h
+        super.slice(:scope, :key, :default, :type, :readonly, :options)
+      end
+
+      class << self
+        def generate(**args)
+          fetch_field_class(args[:type]).new(**args)
+        end
+
+        private
+
+        def fetch_field_class(type)
+          field_class_name = type.to_s.split('_').map(&:capitalize).join('')
+          const_get("::RailsSettings::Fields::#{field_class_name}")
+        end
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/base.rb
+++ b/lib/rails-settings/fields/base.rb
@@ -32,6 +32,7 @@ module RailsSettings
 
       def convert
         return convert_to_value(default_value) if readonly || saved_value.nil?
+
         convert_to_value(saved_value)
       end
 

--- a/lib/rails-settings/fields/base.rb
+++ b/lib/rails-settings/fields/base.rb
@@ -1,11 +1,13 @@
 module RailsSettings
   module Fields
-    class Base < Struct.new(:scope, :key, :default, :readonly, :parent, :separator, :type, :options, keyword_init: true)
+    class Base < Struct.new(:scope, :key, :default, :parent, :readonly, :separator, :type, :options, keyword_init: true)
       SEPARATOR_REGEXP = /[\n,;]+/
 
-      def initialize(scope:, key:, default:, parent:, readonly: false, separator: SEPARATOR_REGEXP, type: :string, options: nil)
-        self.readonly = !!readonly
+      def initialize(scope:, key:, default:, parent:, readonly:, separator:, type:, options:)
         super
+        self.readonly = !!readonly
+        self.type ||= :string
+        self.separator ||= SEPARATOR_REGEXP
       end
 
       def save!(value:)

--- a/lib/rails-settings/fields/base.rb
+++ b/lib/rails-settings/fields/base.rb
@@ -17,7 +17,11 @@ module RailsSettings
       end
 
       def saved_value
-        parent.send(:_value_of, key)
+        return parent.send(:_all_settings)[key] if table_exists?
+
+        # Fallback to default value if table was not ready (before migrate)
+        puts "WARNING: table: \"#{parent.table_name}\" does not exist or not database connection, `#{parent.name}.#{key}` fallback to returns the default value."
+        nil        
       end
 
       def default_value
@@ -35,6 +39,12 @@ module RailsSettings
 
       def to_h
         super.slice(:scope, :key, :default, :type, :readonly, :options)
+      end
+
+      def table_exists?
+        parent.table_exists?
+      rescue StandardError
+        false
       end
 
       class << self

--- a/lib/rails-settings/fields/base.rb
+++ b/lib/rails-settings/fields/base.rb
@@ -11,11 +11,11 @@ module RailsSettings
       end
 
       def save!(value:)
-        converted_value = convert_to_value(value)
+        serialized_value = serialize(value)
         parent_record = parent.find_by(var: key) || parent.new(var: key)
-        parent_record.value = converted_value
+        parent_record.value = serialized_value
         parent_record.save!
-        converted_value
+        parent_record.value
       end
 
       def saved_value
@@ -30,13 +30,17 @@ module RailsSettings
         default.is_a?(Proc) ? default.call : default
       end
 
-      def convert
-        return convert_to_value(default_value) if readonly || saved_value.nil?
+      def read
+        return deserialize(default_value) if readonly || saved_value.nil?
 
-        convert_to_value(saved_value)
+        deserialize(saved_value)
       end
 
-      def convert_to_value(value)
+      def deserialize(value)
+        raise NotImplementedError
+      end
+
+      def serialize(value)
         raise NotImplementedError
       end
 

--- a/lib/rails-settings/fields/big_decimal.rb
+++ b/lib/rails-settings/fields/big_decimal.rb
@@ -1,8 +1,12 @@
 module RailsSettings
   module Fields
     class BigDecimal < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         value.to_d
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
     end
   end

--- a/lib/rails-settings/fields/big_decimal.rb
+++ b/lib/rails-settings/fields/big_decimal.rb
@@ -1,0 +1,11 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class BigDecimal < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        value.to_d
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/big_decimal.rb
+++ b/lib/rails-settings/fields/big_decimal.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class BigDecimal < ::RailsSettings::Fields::Base

--- a/lib/rails-settings/fields/boolean.rb
+++ b/lib/rails-settings/fields/boolean.rb
@@ -1,0 +1,11 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class Boolean < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        ["true", "1", 1, true].include?(value)
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/boolean.rb
+++ b/lib/rails-settings/fields/boolean.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class Boolean < ::RailsSettings::Fields::Base

--- a/lib/rails-settings/fields/boolean.rb
+++ b/lib/rails-settings/fields/boolean.rb
@@ -1,8 +1,12 @@
 module RailsSettings
   module Fields
     class Boolean < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         ["true", "1", 1, true].include?(value)
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
     end
   end

--- a/lib/rails-settings/fields/float.rb
+++ b/lib/rails-settings/fields/float.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class Float < ::RailsSettings::Fields::Base

--- a/lib/rails-settings/fields/float.rb
+++ b/lib/rails-settings/fields/float.rb
@@ -1,8 +1,12 @@
 module RailsSettings
   module Fields
     class Float < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         value.to_f
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
     end
   end

--- a/lib/rails-settings/fields/float.rb
+++ b/lib/rails-settings/fields/float.rb
@@ -1,0 +1,11 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class Float < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        value.to_f
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/hash.rb
+++ b/lib/rails-settings/fields/hash.rb
@@ -1,0 +1,18 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class Hash < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        return value unless value.kind_of?(::String)
+        load_value(value).deep_stringify_keys.with_indifferent_access
+      end
+
+      def load_value(value)
+        YAML.safe_load(value).to_h
+      rescue
+        {}
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/hash.rb
+++ b/lib/rails-settings/fields/hash.rb
@@ -1,10 +1,14 @@
 module RailsSettings
   module Fields
     class Hash < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         return value unless value.is_a?(::String)
 
         load_value(value).deep_stringify_keys.with_indifferent_access
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
 
       def load_value(value)

--- a/lib/rails-settings/fields/hash.rb
+++ b/lib/rails-settings/fields/hash.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class Hash < ::RailsSettings::Fields::Base

--- a/lib/rails-settings/fields/hash.rb
+++ b/lib/rails-settings/fields/hash.rb
@@ -2,13 +2,14 @@ module RailsSettings
   module Fields
     class Hash < ::RailsSettings::Fields::Base
       def convert_to_value(value)
-        return value unless value.kind_of?(::String)
+        return value unless value.is_a?(::String)
+
         load_value(value).deep_stringify_keys.with_indifferent_access
       end
 
       def load_value(value)
         YAML.safe_load(value).to_h
-      rescue
+      rescue StandardError
         {}
       end
     end

--- a/lib/rails-settings/fields/integer.rb
+++ b/lib/rails-settings/fields/integer.rb
@@ -1,8 +1,12 @@
 module RailsSettings
   module Fields
     class Integer < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         value.to_i
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
     end
   end

--- a/lib/rails-settings/fields/integer.rb
+++ b/lib/rails-settings/fields/integer.rb
@@ -1,0 +1,11 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class Integer < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        value.to_i
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/integer.rb
+++ b/lib/rails-settings/fields/integer.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class Integer < ::RailsSettings::Fields::Base

--- a/lib/rails-settings/fields/string.rb
+++ b/lib/rails-settings/fields/string.rb
@@ -1,0 +1,11 @@
+require_relative './base'
+
+module RailsSettings
+  module Fields
+    class String < ::RailsSettings::Fields::Base
+      def convert_to_value(value)
+        value
+      end
+    end
+  end
+end

--- a/lib/rails-settings/fields/string.rb
+++ b/lib/rails-settings/fields/string.rb
@@ -1,8 +1,12 @@
 module RailsSettings
   module Fields
     class String < ::RailsSettings::Fields::Base
-      def convert_to_value(value)
+      def deserialize(value)
         value
+      end
+
+      def serialize(value)
+        deserialize(value)
       end
     end
   end

--- a/lib/rails-settings/fields/string.rb
+++ b/lib/rails-settings/fields/string.rb
@@ -1,5 +1,3 @@
-require_relative './base'
-
 module RailsSettings
   module Fields
     class String < ::RailsSettings::Fields::Base

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -51,13 +51,13 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "setting_keys" do
-    assert_equal 15, Setting.keys.size
+    assert_equal 16, Setting.keys.size
     assert_includes(Setting.keys, "host")
     assert_includes(Setting.keys, "readonly_item")
     assert_includes(Setting.keys, "default_tags")
     assert_includes(Setting.keys, "omniauth_google_options")
 
-    assert_equal 12, Setting.editable_keys.size
+    assert_equal 13, Setting.editable_keys.size
     assert_includes(Setting.editable_keys, "host")
     assert_includes(Setting.editable_keys, "default_tags")
 
@@ -84,7 +84,7 @@ class BaseTest < ActiveSupport::TestCase
     # assert_equal 2, groups.length
     assert_equal %i[application contents mailer none], scopes.keys
     assert_equal 4, scopes[:application].length
-    assert_equal 5, scopes[:contents].length
+    assert_equal 6, scopes[:contents].length
     assert_equal 2, scopes[:mailer].length
   end
 
@@ -305,6 +305,24 @@ class BaseTest < ActiveSupport::TestCase
     Setting.captcha_enable = true
     assert_equal true, Setting.captcha_enable
     assert_equal true, Setting.captcha_enable?
+  end
+
+  test "custom field" do
+    assert_equal 1, Setting.custom_item
+    assert_instance_of Integer, Setting.custom_item
+    assert_no_record :custom_item
+
+    Setting.custom_item = 2
+    assert_equal 2, Setting.custom_item
+    assert_instance_of Integer, Setting.custom_item
+    assert_record_value :custom_item, 'b'
+
+    Setting.custom_item = 3
+    assert_equal 3, Setting.custom_item
+    assert_instance_of Integer, Setting.custom_item
+    assert_record_value :custom_item, 'c'
+
+    assert_raise(StandardError) { Setting.custom_item = 4 }
   end
 
   test "string value in db compatible" do

--- a/test/dummy/app/models/rails_settings/fields/custom.rb
+++ b/test/dummy/app/models/rails_settings/fields/custom.rb
@@ -1,0 +1,23 @@
+module RailsSettings
+  module Fields
+    class Custom < ::RailsSettings::Fields::Base
+      def serialize(value)
+        case value
+        when 'a', 1 then 'a'
+        when 'b', 2 then 'b'
+        when 'c', 3 then 'c'
+        else raise StandardError, 'invalid value'
+        end
+      end
+
+      def deserialize(value)
+        case value
+        when 'a', 1 then 1
+        when 'b', 2 then 2
+        when 'c', 3 then 3
+        else nil
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/app/models/setting.rb
+++ b/test/dummy/app/models/setting.rb
@@ -23,6 +23,7 @@ class Setting < RailsSettings::Base
     field :float_item, type: :float, default: 7
     field :big_decimal_item, type: :big_decimal, default: 9
     field :default_value_with_block, type: :integer, default: -> { 1 + 1 }
+    field :custom_item, type: :custom, default: 1
   end
 
   scope :mailer do


### PR DESCRIPTION
Hi!

Currently, the library supports only a limited number of types - `array, hash, big_decimal, integer, float, string, boolean`.
I have a need to save custom types into a DB, so I decided to try to add the functionality that will allow me to do that. During implementation, I also tried to refactor a little bit of other code in order to make it more readable.

So here is what I've done so far:
- Added ability to define custom types with their own serializers by splitting fields by types into separate classes (https://github.com/MrKirat/rails-settings-cached/tree/kirat/add-ability-to-add-custom-types/lib/rails-settings/fields) and adding dynamic lookup (https://github.com/MrKirat/rails-settings-cached/blob/kirat/add-ability-to-add-custom-types/lib/rails-settings/fields/base.rb#L62-L71)
- Moved the logic of methods defining into a separate class (https://github.com/MrKirat/rails-settings-cached/blob/kirat/add-ability-to-add-custom-types/lib/rails-settings/methods_defining.rb)
- Moved the logic of the cache into a separate module (https://github.com/MrKirat/rails-settings-cached/blob/kirat/add-ability-to-add-custom-types/lib/rails-settings/cache.rb)
- Fixed some Rubocop issues

Take note, that I was trying to keep us much backward compatibility as I can. At this moment it seems like all tests are being passed successfully.

Maintainers (@codez  @berkos  @huacnlee), could you please let me know whether it makes sense? 

If yes, I will prepare the PR for the merge. If not - you are free to close it :)