### PR TITLE
Delay loading of Active Record

### DIFF
--- a/lib/rails-settings-cached.rb
+++ b/lib/rails-settings-cached.rb
@@ -9,7 +9,6 @@ require_relative "rails-settings/fields/hash"
 require_relative "rails-settings/fields/integer"
 require_relative "rails-settings/fields/string"
 
-require_relative "rails-settings/base"
 require_relative "rails-settings/configuration"
 require_relative "rails-settings/request_cache"
 require_relative "rails-settings/middleware"
@@ -17,6 +16,14 @@ require_relative "rails-settings/railtie"
 require_relative "rails-settings/version"
 
 module RailsSettings
+  class ProtectedKeyError < RuntimeError
+    def initialize(key)
+      super("Can't use #{key} as setting key.")
+    end
+  end
+
+  autoload :Base, "rails-settings/base"
+
   module Fields
   end
 end

--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 module RailsSettings
-  class ProtectedKeyError < RuntimeError
-    def initialize(key)
-      super("Can't use #{key} as setting key.")
-    end
-  end
-
   class Base < ActiveRecord::Base
     PROTECTED_KEYS = %w[var value]
     self.table_name = table_name_prefix + "settings"
+
+    after_commit :clear_cache, on: %i[create update destroy]
 
     # get the value field, YAML decoded
     def value

--- a/lib/rails-settings/railtie.rb
+++ b/lib/rails-settings/railtie.rb
@@ -2,10 +2,6 @@
 
 module RailsSettings
   class Railtie < Rails::Railtie
-    initializer "rails_settings.active_record.initialization" do
-      RailsSettings::Base.after_commit :clear_cache, on: %i[create update destroy]
-    end
-
     initializer "rails_settings.configure_rails_initialization" do |app|
       app.middleware.use RailsSettings::Middleware
     end


### PR DESCRIPTION
Referencing `ActiveRecord::Base` as soon as the gem is required cause Active Record being loaded earlier than it should and some Rails configurations not to take effect.

Ref: https://github.com/rails/rails/issues/49827
Ref: https://github.com/mastodon/mastodon/pull/28609

cc @ClearlyClaire @mjankowski